### PR TITLE
Remove redundant `project.build.sourceEncoding` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <properties>
         <revision>1.2</revision>
         <changelist>-SNAPSHOT</changelist>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gitHubRepo>jenkinsci/lib-${project.artifactId}</gitHubRepo>
     </properties>
     <dependencies>


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.