### PR TITLE
Update thread id to use non deprecated method

### DIFF
--- a/src/main/java/io/jenkins/lib/support_log_formatter/SupportLogFormatter.java
+++ b/src/main/java/io/jenkins/lib/support_log_formatter/SupportLogFormatter.java
@@ -61,7 +61,7 @@ public class SupportLogFormatter extends Formatter {
     public String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
         builder.append(formatTime(record));
-        builder.append(" [id=").append(record.getThreadID()).append("]");
+        builder.append(" [id=").append(record.getLongThreadID()).append("]");
 
         builder.append("\t").append(record.getLevel().getName()).append("\t");
 


### PR DESCRIPTION
the threadId used in logs can be synthesised making correlating between threaddumps and logs a bit of guesswork, or in places where a new thread is spawned but with a capture of the spawnings threadId.

Use the non deprecated getLongThreadID https://docs.oracle.com/en/java/javase/17/docs/api/java.logging/java/util/logging/LogRecord.html#getLongThreadID() so that thread IDs

<!-- Please describe your pull request here. -->

### Testing done

None.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
